### PR TITLE
Add Domain Layer

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,11 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
-    id 'kotlin-kapt'
     id 'kotlin-parcelize'
     id 'androidx.navigation.safeargs.kotlin'
     id 'dagger.hilt.android.plugin'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-kapt'
 }
 
 android {

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Comics.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Comics.kt
@@ -1,8 +1,8 @@
 package com.sandoval.marvelcharacters.data.models.marvel_character_detail
 
 data class Comics(
-    val available: Int,
-    val collectionURI: String,
-    val items: List<Item>,
-    val returned: Int
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<Item>?,
+    val returned: Int?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Data.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Data.kt
@@ -1,9 +1,9 @@
 package com.sandoval.marvelcharacters.data.models.marvel_character_detail
 
 data class Data(
-    val count: Int,
-    val limit: Int,
-    val offset: Int,
-    val results: List<Result>,
-    val total: Int
+    val count: Int?,
+    val limit: Int?,
+    val offset: Int?,
+    val results: List<Result>?,
+    val total: Int?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Events.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Events.kt
@@ -1,8 +1,8 @@
 package com.sandoval.marvelcharacters.data.models.marvel_character_detail
 
 data class Events(
-    val available: Int,
-    val collectionURI: String,
-    val items: List<Any>,
-    val returned: Int
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<Item>?,
+    val returned: Int?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Item.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Item.kt
@@ -1,6 +1,6 @@
 package com.sandoval.marvelcharacters.data.models.marvel_character_detail
 
 data class Item(
-    val name: String,
-    val resourceURI: String
+    val name: String?,
+    val resourceURI: String?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/ItemXX.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/ItemXX.kt
@@ -1,7 +1,7 @@
 package com.sandoval.marvelcharacters.data.models.marvel_character_detail
 
 data class ItemXX(
-    val name: String,
-    val resourceURI: String,
-    val type: String
+    val name: String?,
+    val resourceURI: String?,
+    val type: String?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/MarvelCharacterDetailResponse.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/MarvelCharacterDetailResponse.kt
@@ -1,11 +1,11 @@
 package com.sandoval.marvelcharacters.data.models.marvel_character_detail
 
 data class MarvelCharacterDetailResponse(
-    val attributionHTML: String,
-    val attributionText: String,
-    val code: Int,
-    val copyright: String,
-    val data: Data,
-    val etag: String,
-    val status: String
+    val attributionHTML: String?,
+    val attributionText: String?,
+    val code: Int?,
+    val copyright: String?,
+    val data: Data?,
+    val etag: String?,
+    val status: String?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Result.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Result.kt
@@ -1,15 +1,15 @@
 package com.sandoval.marvelcharacters.data.models.marvel_character_detail
 
 data class Result(
-    val comics: Comics,
-    val description: String,
-    val events: Events,
-    val id: Int,
-    val modified: String,
-    val name: String,
-    val resourceURI: String,
-    val series: Series,
-    val stories: Stories,
-    val thumbnail: Thumbnail,
-    val urls: List<Url>
+    val comics: Comics?,
+    val description: String?,
+    val events: Events?,
+    val id: Int?,
+    val modified: String?,
+    val name: String?,
+    val resourceURI: String?,
+    val series: Series?,
+    val stories: Stories?,
+    val thumbnail: Thumbnail?,
+    val urls: List<Url>?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Series.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Series.kt
@@ -1,8 +1,8 @@
 package com.sandoval.marvelcharacters.data.models.marvel_character_detail
 
 data class Series(
-    val available: Int,
-    val collectionURI: String,
-    val items: List<Item>,
-    val returned: Int
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<Item>?,
+    val returned: Int?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Stories.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Stories.kt
@@ -1,8 +1,8 @@
 package com.sandoval.marvelcharacters.data.models.marvel_character_detail
 
 data class Stories(
-    val available: Int,
-    val collectionURI: String,
-    val items: List<ItemXX>,
-    val returned: Int
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<ItemXX>?,
+    val returned: Int?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Thumbnail.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Thumbnail.kt
@@ -1,6 +1,6 @@
 package com.sandoval.marvelcharacters.data.models.marvel_character_detail
 
 data class Thumbnail(
-    val extension: String,
-    val path: String
+    val extension: String?,
+    val path: String?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Url.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Url.kt
@@ -1,6 +1,6 @@
 package com.sandoval.marvelcharacters.data.models.marvel_character_detail
 
 data class Url(
-    val type: String,
-    val url: String
+    val type: String?,
+    val url: String?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Comics.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Comics.kt
@@ -1,8 +1,8 @@
 package com.sandoval.marvelcharacters.data.models.marvel_characters_list
 
 data class Comics(
-    val available: Int,
-    val collectionURI: String,
-    val items: List<Item>,
-    val returned: Int
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<Item>?,
+    val returned: Int?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Data.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Data.kt
@@ -1,9 +1,9 @@
 package com.sandoval.marvelcharacters.data.models.marvel_characters_list
 
 data class Data(
-    val count: Int,
-    val limit: Int,
-    val offset: Int,
-    val results: List<Result>,
-    val total: Int
+    val count: Int?,
+    val limit: Int?,
+    val offset: Int?,
+    val results: List<Result>?,
+    val total: Int?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Events.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Events.kt
@@ -1,8 +1,8 @@
 package com.sandoval.marvelcharacters.data.models.marvel_characters_list
 
 data class Events(
-    val available: Int,
-    val collectionURI: String,
-    val items: List<Item>,
-    val returned: Int
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<Item>?,
+    val returned: Int?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Item.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Item.kt
@@ -1,6 +1,6 @@
 package com.sandoval.marvelcharacters.data.models.marvel_characters_list
 
 data class Item(
-    val name: String,
-    val resourceURI: String
+    val name: String?,
+    val resourceURI: String?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/ItemXXX.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/ItemXXX.kt
@@ -1,7 +1,7 @@
 package com.sandoval.marvelcharacters.data.models.marvel_characters_list
 
 data class ItemXXX(
-    val name: String,
-    val resourceURI: String,
-    val type: String
+    val name: String?,
+    val resourceURI: String?,
+    val type: String?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/MarvelCharactersListResponse.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/MarvelCharactersListResponse.kt
@@ -1,11 +1,11 @@
 package com.sandoval.marvelcharacters.data.models.marvel_characters_list
 
 data class MarvelCharactersListResponse(
-    val attributionHTML: String,
-    val attributionText: String,
-    val code: Int,
-    val copyright: String,
-    val data: Data,
-    val etag: String,
-    val status: String
+    val attributionHTML: String?,
+    val attributionText: String?,
+    val code: Int?,
+    val copyright: String?,
+    val data: Data?,
+    val etag: String?,
+    val status: String?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Result.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Result.kt
@@ -1,15 +1,15 @@
 package com.sandoval.marvelcharacters.data.models.marvel_characters_list
 
 data class Result(
-    val comics: Comics,
-    val description: String,
-    val events: Events,
-    val id: Int,
-    val modified: String,
-    val name: String,
-    val resourceURI: String,
-    val series: Series,
-    val stories: Stories,
-    val thumbnail: Thumbnail,
-    val urls: List<Url>
+    val comics: Comics?,
+    val description: String?,
+    val events: Events?,
+    val id: Int?,
+    val modified: String?,
+    val name: String?,
+    val resourceURI: String?,
+    val series: Series?,
+    val stories: Stories?,
+    val thumbnail: Thumbnail?,
+    val urls: List<Url>?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Series.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Series.kt
@@ -1,8 +1,8 @@
 package com.sandoval.marvelcharacters.data.models.marvel_characters_list
 
 data class Series(
-    val available: Int,
-    val collectionURI: String,
-    val items: List<Item>,
-    val returned: Int
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<Item>?,
+    val returned: Int?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Stories.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Stories.kt
@@ -1,8 +1,8 @@
 package com.sandoval.marvelcharacters.data.models.marvel_characters_list
 
 data class Stories(
-    val available: Int,
-    val collectionURI: String,
-    val items: List<ItemXXX>,
-    val returned: Int
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<ItemXXX>?,
+    val returned: Int?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Thumbnail.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Thumbnail.kt
@@ -1,6 +1,6 @@
 package com.sandoval.marvelcharacters.data.models.marvel_characters_list
 
 data class Thumbnail(
-    val extension: String,
-    val path: String
+    val extension: String?,
+    val path: String?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Url.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Url.kt
@@ -1,6 +1,6 @@
 package com.sandoval.marvelcharacters.data.models.marvel_characters_list
 
 data class Url(
-    val type: String,
-    val url: String
+    val type: String?,
+    val url: String?
 )

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/network/Failure.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/network/Failure.kt
@@ -1,0 +1,12 @@
+package com.sandoval.marvelcharacters.data.network
+
+sealed class Failure {
+
+    object NetworkConnection : Failure()
+    object DataError : Failure()
+    object ServerError : Failure()
+
+    data class FeatureFailure(
+        val errorBody: String
+    ) : Failure()
+}

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/remote/api/MarvelCharactersService.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/remote/api/MarvelCharactersService.kt
@@ -7,14 +7,17 @@ import com.sandoval.marvelcharacters.data.models.marvel_characters_list.MarvelCh
 import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 interface MarvelCharactersService {
 
     //Get Marvel Characters List
     @GET(MARVEL_CHARACTERS_LIST_PATH)
-    suspend fun getMarvelCharactersList(): Response<MarvelCharactersListResponse>
+    suspend fun getMarvelCharactersList(
+        @Query("limit") limit: Int? = null,
+    ): Response<MarvelCharactersListResponse>
 
-    //Get Marvel Characters List
+    //Get Marvel Character Detail
     @GET(MARVEL_CHARACTER_DETAIL_PATH)
     suspend fun getMarvelCharacterDetail(
         @Path("charactersId") charactersId: Int

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/remote/repository/marvel_character_detail/RemoteDataMarvelCharacterDetailRepository.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/remote/repository/marvel_character_detail/RemoteDataMarvelCharacterDetailRepository.kt
@@ -1,4 +1,20 @@
 package com.sandoval.marvelcharacters.data.remote.repository.marvel_character_detail
 
-class RemoteDataMarvelCharacterDetailRepository {
+import com.sandoval.marvelcharacters.data.network.Failure
+import com.sandoval.marvelcharacters.data.remote.api.MarvelCharactersService
+import com.sandoval.marvelcharacters.data.utils.Either
+import com.sandoval.marvelcharacters.domain.models.marvel_character_detail.DResult
+import com.sandoval.marvelcharacters.domain.repository.marvel_character_detail.IGetMarvelCharacterDetailRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class RemoteDataMarvelCharacterDetailRepository @Inject constructor(
+    private val marvelCharactersService: MarvelCharactersService
+) : IGetMarvelCharacterDetailRepository {
+    override suspend fun getMarvelCharacterDetail(charactersId: Int): Flow<Either<Failure, List<DResult>>> =
+        flow {
+            val res = marvelCharactersService.getMarvelCharacterDetail(charactersId)
+            //TODO Emit the result mapping the data through the domain
+        }
 }

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/remote/repository/marvel_characters_list/RemoteDataMarvelCharactersListRepository.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/remote/repository/marvel_characters_list/RemoteDataMarvelCharactersListRepository.kt
@@ -1,4 +1,20 @@
 package com.sandoval.marvelcharacters.data.remote.repository.marvel_characters_list
 
-class RemoteDataMarvelCharactersListRepository {
+import com.sandoval.marvelcharacters.data.network.Failure
+import com.sandoval.marvelcharacters.data.remote.api.MarvelCharactersService
+import com.sandoval.marvelcharacters.data.utils.Either
+import com.sandoval.marvelcharacters.domain.models.marvel_characters_list.DResult
+import com.sandoval.marvelcharacters.domain.repository.marvel_characters_list.IGetMarvelCharactersListRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+class RemoteDataMarvelCharactersListRepository @Inject constructor(
+    private val marvelCharactersService: MarvelCharactersService
+) : IGetMarvelCharactersListRepository {
+    override suspend fun getMarvelCharactersList(limit: Int): Flow<Either<Failure, List<DResult>>> =
+        flow {
+            val res = marvelCharactersService.getMarvelCharactersList(limit)
+            //TODO Emit the result mapping the data through the domain
+        }
 }

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/utils/Either.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/utils/Either.kt
@@ -1,0 +1,63 @@
+package com.sandoval.marvelcharacters.data.utils
+
+/**
+ * Represents a value of one of two possible types (a disjoint union).
+ * Instances of [Either] are either an instance of [Left] or [Right].
+ * FP Convention dictates that [Left] is used for "failure"
+ * and [Right] is used for "success".
+ *
+ * @see Left
+ * @see Right
+ */
+sealed class Either<out L, out R> {
+    /** * Represents the left side of [Either] class which by convention is a "Failure". */
+    data class Left<out L>(val a: L) : Either<L, Nothing>()
+
+    /** * Represents the right side of [Either] class which by convention is a "Success". */
+    data class Right<out R>(val b: R) : Either<Nothing, R>()
+
+    /**
+     * Returns true if this is a Right, false otherwise.
+     * @see Right
+     */
+    val isRight get() = this is Right<R>
+
+    /**
+     * Returns true if this is a Left, false otherwise.
+     * @see Left
+     */
+    val isLeft get() = this is Left<L>
+
+    /**
+     * Creates a Left type.
+     * @see Left
+     */
+    fun <L> left(a: L) =
+        Left(a)
+
+    /**
+     * Creates a Left type.
+     * @see Right
+     */
+    fun <R> right(b: R) =
+        Right(b)
+
+    /**
+     * Applies fnL if this is a Left or fnR if this is a Right.
+     * @see Left
+     * @see Right
+     */
+    fun fold(fnL: (L) -> Any, fnR: (R) -> Any): Any =
+        when (this) {
+            is Left -> fnL(a)
+            is Right -> fnR(b)
+        }
+}
+
+/**
+ * Composes 2 functions
+ * See <a href="https://proandroiddev.com/kotlins-nothing-type-946de7d464fb">Credits to Alex Hart.</a>
+ */
+fun <A, B, C> ((A) -> B).c(f: (B) -> C): (A) -> C = {
+    f(this(it))
+}

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/base/BaseUseCase.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/base/BaseUseCase.kt
@@ -1,0 +1,26 @@
+package com.sandoval.marvelcharacters.domain.base
+
+import com.sandoval.marvelcharacters.data.network.Failure
+import com.sandoval.marvelcharacters.data.utils.Either
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+
+abstract class BaseUseCase<in Params, out Type> where Type : Any {
+
+    abstract suspend fun run(params: Params): Flow<Either<Failure, Type>>
+
+    open operator fun invoke(
+        job: Job,
+        params: Params,
+        onResult: (Either<Failure, Type>) -> Unit = {}
+    ) {
+        val backgroundJob = CoroutineScope(job + Dispatchers.IO).async { run(params) }
+        CoroutineScope(job + Dispatchers.Main).launch {
+            val await = backgroundJob.await()
+            await.catch {
+                onResult(Either.Left(Failure.ServerError))
+            }.collect { d -> onResult(d) }
+        }
+    }
+}

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DComics.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DComics.kt
@@ -1,0 +1,8 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_character_detail
+
+data class DComics(
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<DItem>?,
+    val returned: Int
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DData.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DData.kt
@@ -1,0 +1,9 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_character_detail
+
+data class DData(
+    val count: Int?,
+    val limit: Int?,
+    val offset: Int?,
+    val results: List<DResult>?,
+    val total: Int?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DEvents.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DEvents.kt
@@ -1,0 +1,8 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_character_detail
+
+data class DEvents(
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<DItem>,
+    val returned: Int?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DItem.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DItem.kt
@@ -1,0 +1,6 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_character_detail
+
+data class DItem(
+    val name: String?,
+    val resourceURI: String?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DItemXX.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DItemXX.kt
@@ -1,0 +1,7 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_character_detail
+
+data class DItemXX(
+    val name: String?,
+    val resourceURI: String?,
+    val type: String?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DMarvelCharacterDetailResponse.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DMarvelCharacterDetailResponse.kt
@@ -1,0 +1,11 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_character_detail
+
+data class DMarvelCharacterDetailResponse(
+    val attributionHTML: String?,
+    val attributionText: String?,
+    val code: Int?,
+    val copyright: String?,
+    val data: DData?,
+    val etag: String?,
+    val status: String?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DResult.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DResult.kt
@@ -1,0 +1,15 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_character_detail
+
+data class DResult(
+        val comics: DComics?,
+    val description: String?,
+    val events: DEvents?,
+    val id: Int?,
+    val modified: String?,
+    val name: String?,
+    val resourceURI: String?,
+    val series: DSeries?,
+    val stories: DStories?,
+    val thumbnail: DThumbnail?,
+    val urls: List<DUrl>?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DSeries.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DSeries.kt
@@ -1,0 +1,8 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_character_detail
+
+data class DSeries(
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<DItem>?,
+    val returned: Int?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DStories.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DStories.kt
@@ -1,0 +1,8 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_character_detail
+
+data class DStories(
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<DItemXX>?,
+    val returned: Int?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DThumbnail.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DThumbnail.kt
@@ -1,0 +1,6 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_character_detail
+
+data class DThumbnail(
+    val extension: String?,
+    val path: String?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DUrl.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DUrl.kt
@@ -1,0 +1,6 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_character_detail
+
+data class DUrl(
+    val type: String?,
+    val url: String?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DComics.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DComics.kt
@@ -1,0 +1,8 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_characters_list
+
+data class DComics(
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<DItem>?,
+    val returned: Int?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DData.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DData.kt
@@ -1,0 +1,9 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_characters_list
+
+data class DData(
+    val count: Int?,
+    val limit: Int?,
+    val offset: Int?,
+    val results: List<DResult>?,
+    val total: Int?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DEvents.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DEvents.kt
@@ -1,0 +1,8 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_characters_list
+
+data class DEvents(
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<DItem>?,
+    val returned: Int?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DItem.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DItem.kt
@@ -1,0 +1,6 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_characters_list
+
+data class DItem(
+    val name: String?,
+    val resourceURI: String?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DItemXXX.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DItemXXX.kt
@@ -1,0 +1,7 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_characters_list
+
+data class DItemXXX(
+    val name: String?,
+    val resourceURI: String?,
+    val type: String?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DMarvelCharactersListResponse.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DMarvelCharactersListResponse.kt
@@ -1,0 +1,11 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_characters_list
+
+data class DMarvelCharactersListResponse(
+    val attributionHTML: String?,
+    val attributionText: String?,
+    val code: Int?,
+    val copyright: String?,
+    val data: DData?,
+    val etag: String?,
+    val status: String?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DResult.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DResult.kt
@@ -1,0 +1,15 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_characters_list
+
+data class DResult(
+    val comics: DComics?,
+    val description: String?,
+    val events: DEvents?,
+    val id: Int?,
+    val modified: String?,
+    val name: String?,
+    val resourceURI: String?,
+    val series: DSeries?,
+    val stories: DStories?,
+    val thumbnail: DThumbnail?,
+    val urls: List<DUrl>?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DSeries.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DSeries.kt
@@ -1,0 +1,8 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_characters_list
+
+data class DSeries(
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<DItem>?,
+    val returned: Int?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DStories.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DStories.kt
@@ -1,0 +1,8 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_characters_list
+
+data class DStories(
+    val available: Int?,
+    val collectionURI: String?,
+    val items: List<DItemXXX>?,
+    val returned: Int?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DThumbnail.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DThumbnail.kt
@@ -1,0 +1,6 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_characters_list
+
+data class DThumbnail(
+    val extension: String?,
+    val path: String?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DUrl.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DUrl.kt
@@ -1,0 +1,6 @@
+package com.sandoval.marvelcharacters.domain.models.marvel_characters_list
+
+data class DUrl(
+    val type: String?,
+    val url: String?
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/repository/marvel_character_detail/IGetMarvelCharacterDetailRepository.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/repository/marvel_character_detail/IGetMarvelCharacterDetailRepository.kt
@@ -1,0 +1,12 @@
+package com.sandoval.marvelcharacters.domain.repository.marvel_character_detail
+
+import com.sandoval.marvelcharacters.data.network.Failure
+import com.sandoval.marvelcharacters.data.utils.Either
+import com.sandoval.marvelcharacters.domain.models.marvel_character_detail.DResult
+import kotlinx.coroutines.flow.Flow
+
+interface IGetMarvelCharacterDetailRepository {
+
+    //Remote get marvel character detail Service
+    suspend fun getMarvelCharacterDetail(charactersId: Int): Flow<Either<Failure, List<DResult>>>
+}

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/repository/marvel_characters_list/IGetMarvelCharactersListRepository.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/repository/marvel_characters_list/IGetMarvelCharactersListRepository.kt
@@ -1,0 +1,12 @@
+package com.sandoval.marvelcharacters.domain.repository.marvel_characters_list
+
+import com.sandoval.marvelcharacters.data.network.Failure
+import com.sandoval.marvelcharacters.data.utils.Either
+import com.sandoval.marvelcharacters.domain.models.marvel_characters_list.DResult
+import kotlinx.coroutines.flow.Flow
+
+interface IGetMarvelCharactersListRepository {
+
+    //Remote get marvel character list Service
+    suspend fun getMarvelCharactersList(limit: Int): Flow<Either<Failure, List<DResult>>>
+}

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/usecase/marvel_character_detail/GetMarvelCharacterDetailUseCase.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/usecase/marvel_character_detail/GetMarvelCharacterDetailUseCase.kt
@@ -1,0 +1,17 @@
+package com.sandoval.marvelcharacters.domain.usecase.marvel_character_detail
+
+import com.sandoval.marvelcharacters.data.network.Failure
+import com.sandoval.marvelcharacters.data.utils.Either
+import com.sandoval.marvelcharacters.domain.base.BaseUseCase
+import com.sandoval.marvelcharacters.domain.models.marvel_character_detail.DResult
+import com.sandoval.marvelcharacters.domain.repository.marvel_character_detail.IGetMarvelCharacterDetailRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetMarvelCharacterDetailUseCase @Inject constructor(
+    private val iGetMarvelCharacterDetailRepository: IGetMarvelCharacterDetailRepository
+) : BaseUseCase<Int, List<DResult>>() {
+    override suspend fun run(params: Int): Flow<Either<Failure, List<DResult>>> {
+        return iGetMarvelCharacterDetailRepository.getMarvelCharacterDetail(params)
+    }
+}

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/usecase/marvel_characters_list/GetMarvelCharactersListUseCase.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/usecase/marvel_characters_list/GetMarvelCharactersListUseCase.kt
@@ -1,0 +1,17 @@
+package com.sandoval.marvelcharacters.domain.usecase.marvel_characters_list
+
+import com.sandoval.marvelcharacters.data.network.Failure
+import com.sandoval.marvelcharacters.data.utils.Either
+import com.sandoval.marvelcharacters.domain.base.BaseUseCase
+import com.sandoval.marvelcharacters.domain.models.marvel_characters_list.DResult
+import com.sandoval.marvelcharacters.domain.repository.marvel_characters_list.IGetMarvelCharactersListRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class GetMarvelCharactersListUseCase @Inject constructor(
+    private val iGetMarvelCharactersListRepository: IGetMarvelCharactersListRepository
+) : BaseUseCase<Int, List<DResult>>() {
+    override suspend fun run(params: Int): Flow<Either<Failure, List<DResult>>> {
+        return iGetMarvelCharactersListRepository.getMarvelCharactersList(params)
+    }
+}


### PR DESCRIPTION
- Add the domain layer to map all the data results and operations through the domain.
- Add domain models to be mapped by the data layer in the future
- Add the repository interface to the domain to be implemented in the data layer and to be injected in the UseCase
- Add the use case to get the marvel characters list and marvel character detail, to be injected through the viewmodel in the future
- Create 2 helper clases. Failure.kt to handle possible failure scenarios and Either.kt to be able to calculate the possible result of the operator when the usecase is consumed. Right (Success) Left (Error)