### PR TITLE
Add Viewmodel for Marvel Character List Feature

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/MarvelCharacterDetailResponse.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/MarvelCharacterDetailResponse.kt
@@ -12,12 +12,12 @@ data class MarvelCharacterDetailResponse(
     val status: String?
 ){
     fun toDomainObject() = DMarvelCharacterDetailResponse(
-        attributionHTML = attributionHTML ?: "",
-        attributionText = attributionText ?: "",
-        code = code ?: 0,
-        copyright = copyright ?: "",
-        data = data?.toDomainObject(),
-        etag = etag ?: "",
-        status = status ?: ""
-    )
+            attributionHTML = attributionHTML ?: "",
+            attributionText = attributionText ?: "",
+            code = code ?: 0,
+            copyright = copyright ?: "",
+            data = data?.toDomainObject(),
+            etag = etag ?: "",
+            status = status ?: ""
+        )
 }

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Thumbnail.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_character_detail/Thumbnail.kt
@@ -6,8 +6,9 @@ data class Thumbnail(
     val extension: String?,
     val path: String?
 ){
-    fun toDomainObject() = DThumbnail(
-        extension = extension ?: "",
-        path = path ?: ""
-    )
+    fun toDomainObject() =
+        DThumbnail(
+            extension = extension ?: "",
+            path = path ?: ""
+        )
 }

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/MarvelCharactersListResponse.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/MarvelCharactersListResponse.kt
@@ -11,13 +11,14 @@ data class MarvelCharactersListResponse(
     val etag: String?,
     val status: String?
 ) {
-    fun toDomainObject() = DMarvelCharactersListResponse(
-        attributionHTML = attributionHTML ?: "",
-        attributionText = attributionText ?: "",
-        code = code ?: 0,
-        copyright = copyright ?: "",
-        data = data?.toDomainObject(),
-        etag = etag ?: "",
-        status = status ?: ""
-    )
+    fun toDomainObject() =
+        DMarvelCharactersListResponse(
+            attributionHTML = attributionHTML ?: "",
+            attributionText = attributionText ?: "",
+            code = code ?: 0,
+            copyright = copyright ?: "",
+            data = data?.toDomainObject(),
+            etag = etag ?: "",
+            status = status ?: ""
+        )
 }

--- a/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Thumbnail.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/data/models/marvel_characters_list/Thumbnail.kt
@@ -6,8 +6,9 @@ data class Thumbnail(
     val extension: String?,
     val path: String?
 ) {
-    fun toDomainObject() = DThumbnail(
-        extension = extension ?: "",
-        path = path ?: ""
-    )
+    fun toDomainObject() =
+        DThumbnail(
+            extension = extension ?: "",
+            path = path ?: ""
+        )
 }

--- a/app/src/main/java/com/sandoval/marvelcharacters/di/AppModule.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/di/AppModule.kt
@@ -5,6 +5,8 @@ import com.google.gson.GsonBuilder
 import com.sandoval.marvelcharacters.BuildConfig
 import com.sandoval.marvelcharacters.commons.*
 import com.sandoval.marvelcharacters.data.remote.api.MarvelCharactersService
+import com.sandoval.marvelcharacters.data.remote.repository.marvel_characters_list.RemoteDataMarvelCharactersListRepository
+import com.sandoval.marvelcharacters.domain.repository.marvel_characters_list.IGetMarvelCharactersListRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -91,6 +93,11 @@ object AppModule {
     @Singleton
     fun providesApiService(retrofit: Retrofit): MarvelCharactersService =
         retrofit.create(MarvelCharactersService::class.java)
+
+    @Provides
+    @Singleton
+    fun providesGetEmployeeList(remoteDataMarvelCharactersListRepository: RemoteDataMarvelCharactersListRepository): IGetMarvelCharactersListRepository =
+        remoteDataMarvelCharactersListRepository
 
     fun provideToMd5(encrypted: String): String {
         var pass = encrypted

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DResult.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_character_detail/DResult.kt
@@ -1,7 +1,7 @@
 package com.sandoval.marvelcharacters.domain.models.marvel_character_detail
 
 data class DResult(
-        val comics: DComics?,
+    val comics: DComics?,
     val description: String?,
     val events: DEvents?,
     val id: Int?,

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DResult.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DResult.kt
@@ -1,15 +1,18 @@
 package com.sandoval.marvelcharacters.domain.models.marvel_characters_list
 
+import com.sandoval.marvelcharacters.ui.marvel_characters_list.models.helper.IDResultList
+import com.sandoval.marvelcharacters.ui.marvel_characters_list.models.helper.IThumbnail
+
 data class DResult(
     val comics: DComics?,
-    val description: String?,
+    override val description: String?,
     val events: DEvents?,
-    val id: Int?,
+    override val id: Int?,
     val modified: String?,
-    val name: String?,
+    override val name: String?,
     val resourceURI: String?,
     val series: DSeries?,
     val stories: DStories?,
-    val thumbnail: DThumbnail?,
+    override val thumbnail: IThumbnail?,
     val urls: List<DUrl>?
-)
+) : IDResultList

--- a/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DThumbnail.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/domain/models/marvel_characters_list/DThumbnail.kt
@@ -1,6 +1,8 @@
 package com.sandoval.marvelcharacters.domain.models.marvel_characters_list
 
+import com.sandoval.marvelcharacters.ui.marvel_characters_list.models.helper.IThumbnail
+
 data class DThumbnail(
-    val extension: String?,
-    val path: String?
-)
+    override val extension: String?,
+    override val path: String?
+) : IThumbnail

--- a/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_character_detail/fragments/MarvelCharacterDetailFragment.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_character_detail/fragments/MarvelCharacterDetailFragment.kt
@@ -1,4 +1,4 @@
-package com.sandoval.marvelcharacters.ui.fragments.marvel_character_detail
+package com.sandoval.marvelcharacters.ui.marvel_character_detail.fragments
 
 import android.os.Bundle
 import android.view.LayoutInflater

--- a/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_characters_list/fragments/MarvelCharactersListFragment.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_characters_list/fragments/MarvelCharactersListFragment.kt
@@ -1,4 +1,4 @@
-package com.sandoval.marvelcharacters.ui.fragments.marvel_characters_list
+package com.sandoval.marvelcharacters.ui.marvel_characters_list.fragments
 
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -10,7 +10,7 @@ import com.sandoval.marvelcharacters.databinding.FragmentMarvelCharactersBinding
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MarvelCharactersFragment : Fragment() {
+class MarvelCharactersListFragment : Fragment() {
 
     private var _fragmentMarvelCharactersBinding: FragmentMarvelCharactersBinding? = null
     private val fragmentMarvelCharactersBinding get() = _fragmentMarvelCharactersBinding!!
@@ -24,7 +24,7 @@ class MarvelCharactersFragment : Fragment() {
 
         fragmentMarvelCharactersBinding.goToDetail.setOnClickListener {
             val action =
-                MarvelCharactersFragmentDirections.actionNavigationMarvelCharacterListFragmentToMarvelCharacterDetailFragment()
+                MarvelCharactersListFragmentDirections.actionNavigationMarvelCharacterListFragmentToMarvelCharacterDetailFragment()
             findNavController().navigate(action)
         }
 

--- a/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_characters_list/mapper/MapToPresentation.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_characters_list/mapper/MapToPresentation.kt
@@ -1,0 +1,12 @@
+package com.sandoval.marvelcharacters.ui.marvel_characters_list.mapper
+
+import com.sandoval.marvelcharacters.domain.models.marvel_characters_list.DData
+import com.sandoval.marvelcharacters.ui.marvel_characters_list.models.DMarvelCharactersListDataPresentation
+
+fun DData.toPresentation() = DMarvelCharactersListDataPresentation(
+    count = count ?: 0,
+    limit = limit ?: 0,
+    offset = offset ?: 0,
+    results = results,
+    total = total ?: 0
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_characters_list/models/MarvelCharactersListDataPresentation.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_characters_list/models/MarvelCharactersListDataPresentation.kt
@@ -1,0 +1,15 @@
+package com.sandoval.marvelcharacters.ui.marvel_characters_list.models
+
+import android.os.Parcelable
+import com.sandoval.marvelcharacters.domain.models.marvel_characters_list.DResult
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.RawValue
+
+@Parcelize
+data class DMarvelCharactersListDataPresentation(
+    val count: Int?,
+    val limit: Int?,
+    val offset: Int?,
+    val results: @RawValue List<DResult>?,
+    val total: Int?
+) : Parcelable

--- a/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_characters_list/models/helper/UIMarvelCharacterListModelHelper.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_characters_list/models/helper/UIMarvelCharacterListModelHelper.kt
@@ -1,0 +1,13 @@
+package com.sandoval.marvelcharacters.ui.marvel_characters_list.models.helper
+
+interface IDResultList {
+    val description: String?
+    val id: Int?
+    val name: String?
+    val thumbnail: IThumbnail?
+}
+
+interface IThumbnail {
+    val extension: String?
+    val path: String?
+}

--- a/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_characters_list/models/state/MarvelCharactersListView.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_characters_list/models/state/MarvelCharactersListView.kt
@@ -1,0 +1,10 @@
+package com.sandoval.marvelcharacters.ui.marvel_characters_list.models.state
+
+import com.sandoval.marvelcharacters.ui.marvel_characters_list.models.DMarvelCharactersListDataPresentation
+
+data class MarvelCharactersListView(
+    val loading: Boolean = false,
+    val errorMessage: String? = null,
+    val isEmpty: Boolean = false,
+    val marvelCharactersList: DMarvelCharactersListDataPresentation? = null
+)

--- a/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_characters_list/viewmodel/MarvelCharactersListViewModel.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_characters_list/viewmodel/MarvelCharactersListViewModel.kt
@@ -1,0 +1,62 @@
+package com.sandoval.marvelcharacters.ui.marvel_characters_list.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.sandoval.marvelcharacters.data.network.Failure
+import com.sandoval.marvelcharacters.domain.models.marvel_characters_list.DData
+import com.sandoval.marvelcharacters.domain.models.marvel_characters_list.DResult
+import com.sandoval.marvelcharacters.domain.usecase.marvel_characters_list.GetMarvelCharactersListUseCase
+import com.sandoval.marvelcharacters.ui.marvel_characters_list.mapper.toPresentation
+import com.sandoval.marvelcharacters.ui.marvel_characters_list.models.state.MarvelCharactersListView
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
+import javax.inject.Inject
+
+@HiltViewModel
+class MarvelCharactersListViewModel @Inject constructor(
+    private val marvelCharactersListUseCase: GetMarvelCharactersListUseCase
+) : ViewModel() {
+
+    private val job = Job()
+
+    private val _marvelCharactersListViewModel = MutableLiveData<MarvelCharactersListView>()
+    val marvelCharactersListViewModel: LiveData<MarvelCharactersListView> get() = _marvelCharactersListViewModel
+
+    private val _listMarvelCharactersResults = MutableLiveData<MutableList<DResult>>()
+    val listMarvelCharactersResults: LiveData<MutableList<DResult>> get() = _listMarvelCharactersResults
+
+    fun getResults(limit: Int) {
+        _marvelCharactersListViewModel.value = MarvelCharactersListView(loading = true)
+        marvelCharactersListUseCase(job, limit) {
+            it.fold(
+                ::handleFailure,
+                ::handleSuccess
+            )
+        }
+    }
+
+    private fun handleSuccess(data: DData) {
+        if (data.results?.isEmpty() == true) {
+            _marvelCharactersListViewModel.value = MarvelCharactersListView(loading = false)
+            _marvelCharactersListViewModel.value = MarvelCharactersListView(isEmpty = true)
+        } else {
+            _marvelCharactersListViewModel.value = MarvelCharactersListView(loading = false)
+            val presentation = data.toPresentation()
+            _listMarvelCharactersResults.value = presentation.results?.toMutableList()
+            _marvelCharactersListViewModel.value =
+                MarvelCharactersListView(marvelCharactersList = presentation)
+        }
+    }
+
+    private fun handleFailure(failure: Failure) {
+        _marvelCharactersListViewModel.value = MarvelCharactersListView(loading = false)
+        _marvelCharactersListViewModel.value =
+            MarvelCharactersListView(errorMessage = failure.toString())
+    }
+
+    override fun onCleared() {
+        job.cancel()
+        super.onCleared()
+    }
+}

--- a/app/src/main/res/layout/fragment_marvel_character_detail.xml
+++ b/app/src/main/res/layout/fragment_marvel_character_detail.xml
@@ -9,7 +9,7 @@
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".ui.fragments.marvel_character_detail.MarvelCharacterDetailFragment">
+        tools:context=".ui.marvel_character_detail.fragments.MarvelCharacterDetailFragment">
 
         <TextView
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_marvel_characters.xml
+++ b/app/src/main/res/layout/fragment_marvel_characters.xml
@@ -10,7 +10,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".ui.fragments.marvel_characters_list.MarvelCharactersFragment">
+        tools:context=".ui.marvel_characters_list.fragments.MarvelCharactersListFragment">
 
         <TextView
             android:id="@+id/textView"

--- a/app/src/main/res/navigation/marvel_characters_navigation.xml
+++ b/app/src/main/res/navigation/marvel_characters_navigation.xml
@@ -7,7 +7,7 @@
 
     <fragment
         android:id="@+id/navigation_marve_character_list_fragment"
-        android:name="com.sandoval.marvelcharacters.ui.fragments.marvel_characters_list.MarvelCharactersFragment"
+        android:name="com.sandoval.marvelcharacters.ui.marvel_characters_list.fragments.MarvelCharactersListFragment"
         android:label="Marvel Characters List"
         tools:layout="@layout/fragment_marvel_characters">
         <action
@@ -16,7 +16,7 @@
     </fragment>
     <fragment
         android:id="@+id/navigation_marve_character_detail_fragment"
-        android:name="com.sandoval.marvelcharacters.ui.fragments.marvel_character_detail.MarvelCharacterDetailFragment"
+        android:name="com.sandoval.marvelcharacters.ui.marvel_character_detail.fragments.MarvelCharacterDetailFragment"
         android:label="Marvel Character Detail"
         tools:layout="@layout/fragment_marvel_character_detail" />
 

--- a/app/src/test/java/com/sandoval/marvelcharacters/viewmodel/marvel_characters_list/MarvelCharactersListViewModelTest.kt
+++ b/app/src/test/java/com/sandoval/marvelcharacters/viewmodel/marvel_characters_list/MarvelCharactersListViewModelTest.kt
@@ -1,0 +1,112 @@
+package com.sandoval.marvelcharacters.viewmodel.marvel_characters_list
+
+import com.google.common.truth.Truth
+import com.sandoval.marvelcharacters.data.network.Failure
+import com.sandoval.marvelcharacters.data.utils.Either
+import com.sandoval.marvelcharacters.domain.models.marvel_characters_list.*
+import com.sandoval.marvelcharacters.domain.usecase.marvel_characters_list.GetMarvelCharactersListUseCase
+import com.sandoval.marvelcharacters.ui.marvel_characters_list.mapper.toPresentation
+import com.sandoval.marvelcharacters.ui.marvel_characters_list.viewmodel.MarvelCharactersListViewModel
+import com.sandoval.utils.UnitTest
+import com.sandoval.utils.getOrAwaitValueTest
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import org.junit.Before
+import org.junit.Test
+
+class MarvelCharactersListViewModelTest : UnitTest() {
+
+    @MockK
+    private lateinit var getMarvelCharactersListUseCase: GetMarvelCharactersListUseCase
+
+    private lateinit var marvelCharactersListViewModel: MarvelCharactersListViewModel
+
+    private lateinit var data: DData
+
+    @Before
+    fun setUp() {
+        data =
+            DData(
+                offset = 0, limit = 10, total = 10, count = 10, results = listOf(
+                    DResult(
+                        id = 1,
+                        name = "3-D Man",
+                        description = "description",
+                        modified = "modified",
+                        thumbnail = DThumbnail(
+                            path = "thumbnail.png", extension = "png"
+                        ),
+                        resourceURI = "http://example.com/thumbnail.png",
+                        comics = DComics(
+                            available = 12,
+                            collectionURI = "http://example.com/thumbnail.png",
+                            items = listOf(
+                                DItem(
+                                    resourceURI = "http://example.com/thumbnail.png",
+                                    name = "Avengers"
+                                )
+                            ),
+                            returned = 12
+                        ),
+                        series = DSeries(
+                            available = 12,
+                            collectionURI = "http://example.com/thumbnail.png",
+                            items = listOf(
+                                DItem(
+                                    resourceURI = "http://example.com/thumbnail.png",
+                                    name = "Avengers"
+                                )
+                            ),
+                            returned = 12
+                        ),
+                        stories = DStories(
+                            available = 12,
+                            collectionURI = "http://example.com/thumbnail.png",
+                            items = listOf(
+                                DItemXXX(
+                                    resourceURI = "http://example.com/thumbnail.png",
+                                    name = "Avengers",
+                                    type = "story"
+                                )
+                            ),
+                            returned = 12
+                        ),
+                        events = DEvents(
+                            available = 12,
+                            collectionURI = "http://example.com/thumbnail.png",
+                            items = listOf(
+                                DItem(
+                                    resourceURI = "http://example.com/thumbnail.png",
+                                    name = "Avengers"
+                                )
+                            ),
+                            returned = 12
+                        ),
+                        urls = listOf(
+                            DUrl(
+                                type = "url",
+                                url = "http://example.com/thumbnail.png",
+                            )
+                        ),
+                    )
+                )
+            )
+
+        marvelCharactersListViewModel =
+            MarvelCharactersListViewModel(getMarvelCharactersListUseCase)
+    }
+
+    @Test
+    fun `getMarvelCharactersList should return actual list`() {
+        every { getMarvelCharactersListUseCase(any(), 100, any()) }.answers {
+            lastArg<(Either<Failure, DData>) -> Unit>()(Either.Right(data))
+        }
+        marvelCharactersListViewModel.getResults(100)
+        val res = marvelCharactersListViewModel.marvelCharactersListViewModel.getOrAwaitValueTest()
+        Truth.assertThat(res.errorMessage).isNull()
+        Truth.assertThat(res.loading).isFalse()
+        Truth.assertThat(res.isEmpty).isFalse()
+        Truth.assertThat(res.marvelCharactersList).isEqualTo(data.toPresentation())
+    }
+
+}

--- a/app/src/test/java/com/sandoval/utils/LiveDataUtilTest.kt
+++ b/app/src/test/java/com/sandoval/utils/LiveDataUtilTest.kt
@@ -1,0 +1,47 @@
+package com.sandoval.utils
+
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+/**
+ * Gets the value of a [LiveData] or waits for it to have one, with a timeout.
+ *
+ * Use this extension from host-side (JVM) tests. It's recommended to use it alongside
+ * `InstantTaskExecutorRule` or a similar mechanism to execute tasks synchronously.
+ */
+
+@VisibleForTesting(otherwise = VisibleForTesting.NONE)
+fun <T> LiveData<T>.getOrAwaitValueTest(
+    time: Long = 2,
+    timeUnit: TimeUnit = TimeUnit.SECONDS,
+    afterObserve: () -> Unit = {}
+): T {
+    var data: T? = null
+    val latch = CountDownLatch(1)
+    val observer = object : Observer<T> {
+        override fun onChanged(o: T?) {
+            data = o
+            latch.countDown()
+            this@getOrAwaitValueTest.removeObserver(this)
+        }
+    }
+    this.observeForever(observer)
+
+    try {
+        afterObserve.invoke()
+
+        // Don't wait indefinitely if the LiveData is not set.
+        if (!latch.await(time, timeUnit)) {
+            throw TimeoutException("LiveData value was never set.")
+        }
+    } finally {
+        this.removeObserver(observer)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return data as T
+}


### PR DESCRIPTION
- Add the view-model layer for the feature marvel characters list
- Add a custom state class to map the possible states of the marvel character list use-case in a view model: loading, empty, error or data (MarvelCharactersListView.kt)
- Add a custom mapper package in the UI to map the domain model to a UI model to be passed in the view-model, in this case for the Marvel Characters list use-case
- Add a util class to be able to get the value of a LiveData, or waits for it to have one, with a timeout; to be used in the view-model unit-tests classes
- Add the view-model unit test for the Marvel Characters list use-case