### PR TITLE
Juansandoval/m016 render marvel characters detail using data from marvel character detail viewmodel

### DIFF
--- a/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_character_detail/fragments/MarvelCharacterDetailFragment.kt
+++ b/app/src/main/java/com/sandoval/marvelcharacters/ui/marvel_character_detail/fragments/MarvelCharacterDetailFragment.kt
@@ -1,9 +1,13 @@
 package com.sandoval.marvelcharacters.ui.marvel_character_detail.fragments
 
+import android.util.Log
 import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
+import coil.load
+import com.sandoval.marvelcharacters.R
 import com.sandoval.marvelcharacters.databinding.FragmentMarvelCharacterDetailBinding
+import com.sandoval.marvelcharacters.domain.models.marvel_character_detail.DResult
 import com.sandoval.marvelcharacters.ui.base.BaseFragment
 import com.sandoval.marvelcharacters.ui.marvel_character_detail.viewmodel.MarvelCharacterDetailViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -32,11 +36,45 @@ class MarvelCharacterDetailFragment : BaseFragment<FragmentMarvelCharacterDetail
                     hideLoading()
                 }
                 it.marvelCharacterDetail != null -> {
+                    when {
+                        it.marvelCharacterDetail.results.isNullOrEmpty() -> {
+                            Log.e("Marvel Character Detail", "No error found")
+                        }
+                        else -> {
+                            setupMarvelCharacterDetailView(it.marvelCharacterDetail.results)
+                        }
+                    }
+
                     hideLoading()
                 }
                 it.errorMessage != null -> {
                     hideLoading()
                 }
+            }
+        }
+
+    }
+
+    private fun setupMarvelCharacterDetailView(results: List<DResult>) {
+        binding.marvelCharacterNameDetail.text = results.first().name.toString()
+        binding.marvelCharacterDescriptionDetail.text = results.first().description.toString()
+        val thumbnailPath = results.first().thumbnail?.path
+        val thumbnailExtension = results.first().thumbnail?.extension
+
+        when {
+            thumbnailPath != null && thumbnailExtension != null -> {
+                val thumbnailUrl = "$thumbnailPath.$thumbnailExtension"
+                Log.d("ThumbnailUrl", thumbnailUrl)
+                binding.marvelCharacterImageDetail.load(thumbnailUrl) {
+                    crossfade(300)
+                    listener(onError = { _, _ ->
+                        binding.marvelCharacterImageDetail.setImageResource(R.drawable.ic_no_picture_256)
+                    })
+                }
+
+            }
+            else -> {
+                binding.marvelCharacterImageDetail.setImageResource(R.drawable.ic_no_picture_256)
             }
         }
     }

--- a/app/src/main/res/drawable/ic_share_button.xml
+++ b/app/src/main/res/drawable/ic_share_button.xml
@@ -1,0 +1,5 @@
+<vector android:height="32dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="32dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,16.08c-0.76,0 -1.44,0.3 -1.96,0.77L8.91,12.7c0.05,-0.23 0.09,-0.46 0.09,-0.7s-0.04,-0.47 -0.09,-0.7l7.05,-4.11c0.54,0.5 1.25,0.81 2.04,0.81 1.66,0 3,-1.34 3,-3s-1.34,-3 -3,-3 -3,1.34 -3,3c0,0.24 0.04,0.47 0.09,0.7L8.04,9.81C7.5,9.31 6.79,9 6,9c-1.66,0 -3,1.34 -3,3s1.34,3 3,3c0.79,0 1.5,-0.31 2.04,-0.81l7.12,4.16c-0.05,0.21 -0.08,0.43 -0.08,0.65 0,1.61 1.31,2.92 2.92,2.92 1.61,0 2.92,-1.31 2.92,-2.92s-1.31,-2.92 -2.92,-2.92z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_marvel_character_detail.xml
+++ b/app/src/main/res/layout/fragment_marvel_character_detail.xml
@@ -21,7 +21,6 @@
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="32dp"
             android:scaleType="centerCrop"
-            tools:src="@drawable/ic_no_picture_256"
             app:layout_constraintBottom_toTopOf="@+id/marvel_character_name_detail"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"

--- a/app/src/main/res/layout/fragment_marvel_character_detail.xml
+++ b/app/src/main/res/layout/fragment_marvel_character_detail.xml
@@ -12,14 +12,77 @@
         android:layout_height="match_parent"
         tools:context=".ui.marvel_character_detail.fragments.MarvelCharacterDetailFragment">
 
+        <ImageView
+            android:id="@+id/marvel_character_image_detail"
+            android:layout_width="300dp"
+            android:layout_height="300dp"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="32dp"
+            android:scaleType="centerCrop"
+            tools:src="@drawable/ic_no_picture_256"
+            app:layout_constraintBottom_toTopOf="@+id/marvel_character_name_detail"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/loading_spinner"
+            android:contentDescription="Marvel Character Image Detail" />
+
         <TextView
-            android:layout_width="wrap_content"
+            android:id="@+id/marvel_character_name_detail"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:text="Marvel Characters Detail Fragment"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="16dp"
+            android:ellipsize="end"
+            android:fontFamily="@font/roboto_medium"
+            android:maxLength="100"
+            android:textAlignment="center"
+            android:textColor="@color/black"
+            android:textSize="20sp"
+            app:layout_constraintBottom_toTopOf="@+id/marvel_character_description_detail"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/marvel_character_image_detail"
+            tools:text="A-Bomb (HAS)" />
+
+        <TextView
+            android:id="@+id/marvel_character_description_detail"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="24dp"
+            android:ellipsize="end"
+            android:fontFamily="@font/roboto_medium"
+            android:maxLength="400"
+            android:textColor="@color/black"
+            android:textSize="16sp"
+            app:layout_constraintBottom_toTopOf="@+id/marvel_character_image_share"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/marvel_character_name_detail"
+            tools:text="Rick Jones has been Hulk's best bud since day one, but now he's more than a friend...he's a teammate! Transformed by a Gamma energy explosion, A-Bomb's thick, armored skin is just as strong and powerful as it is blue. And when he curls into action, he uses it like a giant bowling ball of destruction! " />
+
+        <ImageView
+            android:id="@+id/marvel_character_image_share"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_marginTop="16dp"
+            android:scaleType="centerCrop"
+            android:src="@drawable/ic_share_button"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@+id/marvel_character_description_detail"
+            android:contentDescription="Share icon image" />
 
         <include
             android:id="@+id/loading_spinner"
@@ -27,10 +90,12 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/marvel_character_image_detail"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_chainStyle="packed" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>


### PR DESCRIPTION
- Add the marvel character detail viewmodel implementation to bring the data to be rendered in the UI for the marvel character detail
- Add to the MarvelCharacterDetailFragment.kt a different way to render the information using the binding directly through the class.
- As DResult is a collection but the detail of the marvel character is returning only 1 position (should be refactored to bring a class not a collection) the method to render the UI is getting the .first() position for the DResult class regarding the detail (name, description, image)
- Add the shared icon to be used in future functionality to share the information about the marvel character to third party apps.
- Delete the tools:src for the fragment_marvel_character_detail.xml